### PR TITLE
Rm abs

### DIFF
--- a/bash/install_DAISIErobustness.sh
+++ b/bash/install_DAISIErobustness.sh
@@ -10,4 +10,4 @@
 mkdir -p logs
 mkdir -p results
 ml R
-Rscript -e "remotes::install_github('Neves-P/DAISIErobustness@rm_abs')"
+Rscript -e "remotes::install_github('Neves-P/DAISIErobustness@develop')"

--- a/bash/install_DAISIErobustness.sh
+++ b/bash/install_DAISIErobustness.sh
@@ -10,4 +10,4 @@
 mkdir -p logs
 mkdir -p results
 ml R
-Rscript -e "remotes::install_github('Neves-P/DAISIErobustness@develop')"
+Rscript -e "remotes::install_github('Neves-P/DAISIErobustness@rm_abs')"

--- a/bash/submit_run_robustness_param_set.sh
+++ b/bash/submit_run_robustness_param_set.sh
@@ -34,12 +34,8 @@
 param_space_name=$1
 param_set=$2
 replicates=$3
-distance_method=$4
 
 ml R
 Rscript scripts/analysis/run_robustness_peregrine.R ${param_space_name} \
                                                     ${param_set} \
-                                                    ${replicates} \
-                                                    ${distance_method}
-
-
+                                                    ${replicates}

--- a/bash/submit_run_robustness_param_set_regular.sh
+++ b/bash/submit_run_robustness_param_set_regular.sh
@@ -34,12 +34,8 @@
 param_space_name=$1
 param_set=$2
 replicates=$3
-distance_method=$4
 
 ml R
 Rscript scripts/analysis/run_robustness_peregrine.R ${param_space_name} \
                                                     ${param_set} \
-                                                    ${replicates} \
-                                                    ${distance_method}
-
-
+                                                    ${replicates}

--- a/bash/submit_run_robustness_param_set_regular_shorter.sh
+++ b/bash/submit_run_robustness_param_set_regular_shorter.sh
@@ -34,12 +34,10 @@
 param_space_name=$1
 param_set=$2
 replicates=$3
-distance_method=$4
 
 ml R
 Rscript scripts/analysis/run_robustness_peregrine.R ${param_space_name} \
                                                     ${param_set} \
-                                                    ${replicates} \
-                                                    ${distance_method}
+                                                    ${replicates}
 
 

--- a/bash/submit_run_robustness_param_set_shorter.sh
+++ b/bash/submit_run_robustness_param_set_shorter.sh
@@ -34,12 +34,8 @@
 param_space_name=$1
 param_set=$2
 replicates=$3
-distance_method=$4
 
 ml R
 Rscript scripts/analysis/run_robustness_peregrine.R ${param_space_name} \
                                                     ${param_set} \
-                                                    ${replicates} \
-                                                    ${distance_method}
-
-
+                                                    ${replicates}

--- a/bash/submit_run_robustness_peregrine.sh
+++ b/bash/submit_run_robustness_peregrine.sh
@@ -39,23 +39,19 @@
 #   trait_CES
 # replicates - Total number of replicates to be simulated, or are present in
 #   the input simulation.
-# distance_method - If the absolute or squared distance between nLTTs should be
-#   computed. Options:
-#     abs - (default)
-#     squ
 ################################################################################
 ##### Before running make sure logs folder has been created! ####
 ## Usage example running simulations for the oceanic_ontogeny param space, 1000
 ## replicates, entire parameter space:
 # git clone https://github.com/Neves-P/DAISIErobustness.git
 # cd DAISIErobustness
-# sbatch bash/submit_run_robustness_peregrine.sh oceanic_ontogeny 1000 abs
+# sbatch bash/submit_run_robustness_peregrine.sh oceanic_ontogeny 1000
 #
 ## Usage example running analysis for the continental param space, 1000
 ## replicates, entire parameter space:
 # git clone https://github.com/Neves-P/DAISIErobustness.git
 # cd DAISIErobustness
-# sbatch bash/submit_run_robustness_peregrine.sh continental 1000 abs
+# sbatch bash/submit_run_robustness_peregrine.sh continental 1000
 ################################################################################
 
 
@@ -65,7 +61,6 @@ ml R
 
 param_space_name=$1
 replicates=$2
-distance_method=$3
 
 data_path=`Rscript -e "load('inst/extdata/$1.rda'); nrow($1)"`
 for_length=`echo $data_path | awk '{ print substr( $0, 5 ) }'`
@@ -75,6 +70,5 @@ for (( param_set = 1; param_set <= $for_length; param_set++ ))
 do
   sbatch bash/submit_run_robustness_param_set.sh ${param_space_name} \
                                                  ${param_set} \
-                                                 ${replicates} \
-                                                 ${distance_method}
+                                                 ${replicates}
 done

--- a/bash/submit_run_robustness_peregrine_regular.sh
+++ b/bash/submit_run_robustness_peregrine_regular.sh
@@ -40,23 +40,19 @@
 #   oceanic
 # replicates - Total number of replicates to be simulated, or are present in
 #   the input simulation.
-# distance_method - If the absolute or squared distance between nLTTs should be
-#   computed. Options:
-#     abs - (default)
-#     squ
 ################################################################################
 ##### Before running make sure logs folder has been created! ####
 ## Usage example running simulations for the oceanic_ontogeny param space, 1000
 ## replicates, entire parameter space:
 # git clone https://github.com/Neves-P/DAISIErobustness.git
 # cd DAISIErobustness
-# sbatch bash/submit_run_robustness_peregrine.sh oceanic_ontogeny 1000 novel_sim abs
+# sbatch bash/submit_run_robustness_peregrine.sh oceanic_ontogeny 1000 novel_sim
 #
 ## Usage example running analysis for the continental param space, 1000
 ## replicates, entire parameter space:
 # git clone https://github.com/Neves-P/DAISIErobustness.git
 # cd DAISIErobustness
-# sbatch bash/submit_run_robustness_peregrine.sh continental 1000 analysis abs
+# sbatch bash/submit_run_robustness_peregrine.sh continental 1000
 ################################################################################
 
 
@@ -66,7 +62,6 @@ ml R
 
 param_space_name=$1
 replicates=$2
-distance_method=$3
 
 data_path=`Rscript -e "load('inst/extdata/$1.rda'); nrow($1)"`
 for_length=`echo $data_path | awk '{ print substr( $0, 5 ) }'`
@@ -76,6 +71,5 @@ for (( param_set = 1; param_set <= $for_length; param_set++ ))
 do
   sbatch bash/submit_run_robustness_param_set_regular.sh ${param_space_name} \
                                                              ${param_set} \
-                                                             ${replicates} \
-                                                             ${distance_method}
+                                                             ${replicates}
 done

--- a/bash/submit_run_robustness_peregrine_regular_shorter.sh
+++ b/bash/submit_run_robustness_peregrine_regular_shorter.sh
@@ -40,23 +40,19 @@
 #   oceanic
 # replicates - Total number of replicates to be simulated, or are present in
 #   the input simulation.
-# distance_method - If the absolute or squared distance between nLTTs should be
-#   computed. Options:
-#     abs - (default)
-#     squ
 ################################################################################
 ##### Before running make sure logs folder has been created! ####
 ## Usage example running simulations for the oceanic_ontogeny param space, 1000
 ## replicates, entire parameter space:
 # git clone https://github.com/Neves-P/DAISIErobustness.git
 # cd DAISIErobustness
-# sbatch bash/submit_run_robustness_peregrine.sh oceanic_ontogeny 1000 novel_sim abs
+# sbatch bash/submit_run_robustness_peregrine.sh oceanic_ontogeny 1000 novel_sim
 #
 ## Usage example running analysis for the continental param space, 1000
 ## replicates, entire parameter space:
 # git clone https://github.com/Neves-P/DAISIErobustness.git
 # cd DAISIErobustness
-# sbatch bash/submit_run_robustness_peregrine.sh continental 1000 analysis abs
+# sbatch bash/submit_run_robustness_peregrine.sh continental 1000 analysis
 ################################################################################
 
 
@@ -66,7 +62,6 @@ ml R
 
 param_space_name=$1
 replicates=$2
-distance_method=$3
 
 data_path=`Rscript -e "load('inst/extdata/$1.rda'); nrow($1)"`
 for_length=`echo $data_path | awk '{ print substr( $0, 5 ) }'`
@@ -76,6 +71,5 @@ for (( param_set = 1; param_set <= $for_length; param_set++ ))
 do
   sbatch bash/submit_run_robustness_param_set_regular_shorter.sh ${param_space_name} \
                                                              ${param_set} \
-                                                             ${replicates} \
-                                                             ${distance_method}
+                                                             ${replicates}
 done

--- a/bash/submit_run_robustness_peregrine_shorter.sh
+++ b/bash/submit_run_robustness_peregrine_shorter.sh
@@ -39,23 +39,19 @@
 #   trait_CES
 # replicates - Total number of replicates to be simulated, or are present in
 #   the input simulation.
-# distance_method - If the absolute or squared distance between nLTTs should be
-#   computed. Options:
-#     abs - (default)
-#     squ
 ################################################################################
 ##### Before running make sure logs folder has been created! ####
 ## Usage example running simulations for the oceanic_ontogeny param space, 1000
 ## replicates, entire parameter space:
 # git clone https://github.com/Neves-P/DAISIErobustness.git
 # cd DAISIErobustness
-# sbatch bash/submit_run_robustness_peregrine.sh oceanic_ontogeny 1000 abs
+# sbatch bash/submit_run_robustness_peregrine.sh oceanic_ontogeny 1000
 #
 ## Usage example running analysis for the continental param space, 1000
 ## replicates, entire parameter space:
 # git clone https://github.com/Neves-P/DAISIErobustness.git
 # cd DAISIErobustness
-# sbatch bash/submit_run_robustness_peregrine.sh continental 1000 abs
+# sbatch bash/submit_run_robustness_peregrine.sh continental 1000
 ################################################################################
 
 
@@ -65,7 +61,6 @@ ml R
 
 param_space_name=$1
 replicates=$2
-distance_method=$3
 
 data_path=`Rscript -e "load('inst/extdata/$1.rda'); nrow($1)"`
 for_length=`echo $data_path | awk '{ print substr( $0, 5 ) }'`
@@ -75,6 +70,5 @@ for (( param_set = 1; param_set <= $for_length; param_set++ ))
 do
   sbatch bash/submit_run_robustness_param_set_shorter.sh ${param_space_name} \
                                                  ${param_set} \
-                                                 ${replicates} \
-                                                 ${distance_method}
+                                                 ${replicates}
 done

--- a/scripts/analysis/run_robustness_peregrine.R
+++ b/scripts/analysis/run_robustness_peregrine.R
@@ -3,7 +3,6 @@ args <- commandArgs(TRUE)
 param_space_name <- args[1]
 param_set <- as.numeric(args[2])
 replicates <- as.numeric(args[3])
-distance_method <- args[4]
 save_output <- TRUE
 
 library(DAISIErobustness)
@@ -12,6 +11,5 @@ run_robustness(
   param_space_name = param_space_name,
   param_set = param_set,
   replicates = replicates,
-  distance_method = distance_method,
   save_output = save_output
 )


### PR DESCRIPTION
Removed the use of the abs parameter from bash scripts. I have run a pilot of two parameter spaces on the cluster and have found that the jobs run and save normally. If you are happy with the changes you can delete the branch after accepting the PR.