### PR TITLE
`replicates` seems like an unused argument in `calc_error()`.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,5 +63,5 @@ Remotes:
     thijsjanzen/nltt
 URL: https://github.com/Neves-P/DAISIErobustness
 BugReports: https://github.com/Neves-P/DAISIErobustness/issues
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr

--- a/R/calc_error.R
+++ b/R/calc_error.R
@@ -25,7 +25,6 @@
 calc_error <- function(sim_1,
                        sim_2,
                        sim_pars,
-                       replicates,
                        distance_method) {
   spec_nltt_error <- c()
   num_spec_error <- c()

--- a/R/run_robustness.R
+++ b/R/run_robustness.R
@@ -230,7 +230,6 @@ run_robustness <- function(param_space_name,
         sim_1 = novel_sim,
         sim_2 = oceanic_sim_1,
         sim_pars = sim_pars,
-        replicates = replicates,
         distance_method = distance_method)
 
       oceanic_ml <- calc_ml(
@@ -261,7 +260,6 @@ run_robustness <- function(param_space_name,
           sim_1 = oceanic_sim_1,
           sim_2 = oceanic_sim_2,
           sim_pars = sim_pars,
-          replicates = replicates,
           distance_method = distance_method)
 
         spec_nltt_error <- append(

--- a/man/calc_error.Rd
+++ b/man/calc_error.Rd
@@ -4,7 +4,7 @@
 \alias{calc_error}
 \title{Calculates error metrics between two simulations}
 \usage{
-calc_error(sim_1, sim_2, sim_pars, replicates, distance_method)
+calc_error(sim_1, sim_2, sim_pars, distance_method)
 }
 \arguments{
 \item{sim_1}{A list of simulation output from
@@ -20,9 +20,6 @@ calc_error(sim_1, sim_2, sim_pars, replicates, distance_method)
 \code{\link[DAISIE]{DAISIE_sim_trait_dep}()}.}
 
 \item{sim_pars}{A list of simulation parameters.}
-
-\item{replicates}{A numeric for the number of replicates for the
-simulations}
 
 \item{distance_method}{From the nLTT package.
 How the difference between the two nLTTs is summed:


### PR DESCRIPTION
I found `replicates` seems like an unused argument in `calc_mu()`, so I deleted it to avoid further confusion.